### PR TITLE
Disable Renovate updates for pinned Node/npm metadata

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,6 +51,13 @@
       "matchDepNames": ["node"],
       "allowedVersions": "22.22.2",
       "addLabels": ["node"]
+    },
+    {
+      "description": "Do not manage pinned Node/npm toolchain declarations in package metadata.",
+      "matchManagers": ["npm"],
+      "matchDepNames": ["node", "npm"],
+      "matchDepTypes": ["engines", "packageManager"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Disable Renovate npm-manager updates for pinned Node/npm toolchain declarations in package metadata
- Keep normal npm dependency updates enabled
- Leave the existing GitHub Actions Node rule unchanged

Closes #82

## Validation

- Parsed .github/renovate.json with Node JSON.parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to refine how Node.js and npm version updates are handled within the project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pianowow/freedle/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->