### PR TITLE
Allow one-shot Renovate PR creation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,12 +3,12 @@
   "extends": ["config:recommended"],
   "description": "Keep Freedle dependencies moving in small, reviewable updates.",
   "timezone": "America/New_York",
-  "schedule": ["* 16-19 * * 5"],
+  "schedule": ["at any time"],
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "automerge": false,
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 5,
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
   "enabledManagers": ["npm", "github-actions"],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- Let Renovate create eligible PRs during any manual or scheduled workflow run
- Remove Renovate's internal Friday-only PR creation window
- Disable hourly and concurrent PR creation limits
- Keep the dependency dashboard enabled for visibility

Closes #84

## Validation

- Parsed .github/renovate.json with Node JSON.parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pianowow/freedle/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->